### PR TITLE
Static factory  create method

### DIFF
--- a/src/Adapter/FactoryAdapter.php
+++ b/src/Adapter/FactoryAdapter.php
@@ -14,7 +14,7 @@ class FactoryAdapter
      * @param  array  $logger
      * @return MessageQueuePHP\Adapter\AMQPAdapter
      */
-    public function create(
+    public static function create(
         array $connection,
         array $queues,
         array $exchanges,


### PR DESCRIPTION
Makes the factory  create method static, so Symfony will stop complain about the create method not be static.