### PR TITLE
fix: removes try-catch do construtor do AMQPAdapter

### DIFF
--- a/src/Adapter/AMQPAdapter.php
+++ b/src/Adapter/AMQPAdapter.php
@@ -50,18 +50,14 @@ class AMQPAdapter implements AdapterInterface
      */
     public function __construct(ConfigInterface $config)
     {
-        try {
-            $this->config     = $config->getConfig();
-            $this->logger     = $this->prepareLogger($config);
-            $this->connection = $this->prepareConnection();
-            $this->channel    = $this->connection->channel();
-            $this->setQueues();
-            $this->setExchanges();
-        } catch (Exception $exception) {
-            throw new Exception('AMQPAdapter can not be loaded.
-                Check config settings and/or access to AMQP Server');
-        }
+        $this->config     = $config->getConfig();
+        $this->logger     = $this->prepareLogger($config);
+        $this->connection = $this->prepareConnection();
+        $this->channel    = $this->connection->channel();
+        $this->setQueues();
+        $this->setExchanges();
     }
+
 
     /**
      * @return PhpAmqpLib\Connection\AMQPStreamConnection


### PR DESCRIPTION
Este Pull Request remove o bloco try-catch do construtor do AMQPAdapter, permitindo que as exceções sejam propagadas diretamente caso ocorram problemas na configuração ou na conexão com o servidor AMQP. 

Ao fazer isso, a detecção de falhas torna-se mais clara, evitando mascarar erros e mantendo a coerência com o padrão utilizado no método "send", que faz log e relança as exceções sem substituí-las por mensagens genéricas. 

Com esta mudança, ficará mais fácil diagnosticar e corrigir problemas de inicialização no AMQPAdapter.
